### PR TITLE
Add .destroy() to clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Checks if a user is idle for a configurable amount of time and fires a callback
 
 ### Usage
 ```js
-idleTimer({
+var timer = idleTimer({
   // function to fire after idle
   callback: callbackFn,
   // Amount of time in milliseconds before becoming idle. default 60000
@@ -15,4 +15,8 @@ idleTimer({
 function callbackFn () {
   console.log("You're idle!");
 }
+
+// when no longer needed, destroy() will remove
+// all of the event listeners and clear the timeouts
+timer.destroy();
 ```

--- a/index.js
+++ b/index.js
@@ -15,16 +15,26 @@ function idleTimer(options) {
   var callback = options.callback || function() {};
   var idleTime = options.idleTime || 60000;
   var timer;
-  
-  window.onload = resetTimer;
-  document.onmousemove = resetTimer;
-  document.onscroll = resetTimer;
-  document.onkeypress = resetTimer;
 
+  addOrRemoveEvents('addEventListener');
   resetTimer();
+
+  function addOrRemoveEvents(addOrRemove) {
+    window[addOrRemove]('load', resetTimer);
+    document[addOrRemove]('mousemove', resetTimer);
+    document[addOrRemove]('scroll', resetTimer);
+    document[addOrRemove]('keypress', resetTimer);
+  }
 
   function resetTimer() {
     clearTimeout(timer);
     timer = setTimeout(callback, idleTime);
   }
+
+  return {
+    destroy: function() {
+      clearTimeout(timer);
+      addOrRemoveEvents('removeEventListener');
+    }
+  };
 }

--- a/test.js
+++ b/test.js
@@ -6,6 +6,20 @@ test('idleTimer is a function', function (t) {
   t.end();
 });
 
+test('idleTimer.destroy removes the listeners', function (t) {
+  var foo = 'nothing happened';
+  t.plan(1);
+  idleTimer({
+    callback: function() {
+      foo = 'beep';
+    },
+    idleTime: 10
+  }).destroy();
+  setTimeout(function() {
+    t.equal(foo, 'nothing happened');
+  }, 11);
+});
+
 test('idleTimer callback gets called after being idle', function (t) {
   var foo;
   t.plan(2);


### PR DESCRIPTION
Add support for `timer.destroy()`, in order to cleanly stop listening to the page when the `idleTimer` is no longer needed.
